### PR TITLE
JENKINS-53020 updated to java7 and maven-plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
   <properties>
     <maven.findbugs.failure.strict>false</maven.findbugs.failure.strict>
-    <jenkins.version>1.580.1</jenkins.version>
+    <jenkins.version>1.625.3</jenkins.version>
     <java.level>7</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
   <properties>
     <maven.findbugs.failure.strict>false</maven.findbugs.failure.strict>
     <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
   </properties>
 
   <repositories>
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.5</version>
+      <version>3.1.2</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
maven-plugin update necessitated updating to java7

plexus-utils:3.0.10 is vulnerable to CVE-2017-1000487
before commit:
- org.jenkins-ci.main:maven-plugin:jar:2.5:compile
 \- org.apache.maven:maven-core:jar:3.1.0:compile
   \- org.codehaus.plexus:plexus-utils:jar:3.0.10:compile

after commit:
- org.jenkins-ci.main:maven-plugin:jar:3.1.2:compile
 \- org.codehaus.plexus:plexus-utils:jar:3.0.24:compile

@reviewbybees 