### PR TITLE
[Hacktoberfest] Migrate docs to jenkinsci repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+## Version History
+
+### Version 1.2 (2019-06-11)
+
+-   Update icu4j and various other dependencies.
+-   Code cleanups and bug fixes
+
+### Version 1.1 (2015-06-15)
+
+-   Fix broken icons
+
+### Version 1.0 (2014-10-29)
+
+-   Initial release (spun out from the [CloudBees
+    Deployer](https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-deployer-plugin/)
+    plugin)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Jenkins Deployer Framework Plugin
 =================================
 
-Read more: [http://wiki.jenkins-ci.org/display/JENKINS/Deployer+Framework+Plugin](http://wiki.jenkins-ci.org/display/JENKINS/Deployer+Framework+Plugin)
+This plugin provides a framework for deploying applications. Other plugins provide engines that plug in to this framework and perform the actual deployments.
 
 Development
 ===========
@@ -25,7 +25,7 @@ To install:
 
 1. copy the resulting ./target/deployer-framework.hpi file to the $JENKINS_HOME/plugins directory. Don't forget to restart Jenkins afterwards.
 
-2. or use the plugin management console (http://example.com:8080/pluginManager/advanced) to upload the hpi file. You have to restart Jenkins in order to find the pluing in the installed plugins list.
+2. or use the plugin management console (http://example.com:8080/pluginManager/advanced) to upload the hpi file. You have to restart Jenkins in order to find the plugin in the installed plugins list.
 
 
 Plugin releases

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <description>
     This plugin provides a framework for deploying applications.
   </description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Deployer+Framework+Plugin</url>
+  <url>https://github.com/jenkinsci/deployer-framework-plugin</url>
   <licenses>
     <license>
       <name>MIT</name>


### PR DESCRIPTION
This PR migrates the Deployer Framework plugin documentation from the **plugins-wiki-docs** repo to the **deployer-framework-plugin** repo as part of the Hacktoberfest docs-to-code project. It includes the following changes:

- Merges the content from the wiki into the README.md file (only the plugin description, in this case)
- Creates a CHANGELOG.md file and copies the version history information from the wiki into it
- Updates the pom.xml file with the new URL for the docs
- Fixes a broken link in the version history
- Fixes a typo

Please add the **hacktoberfest-accepted** label if you approve this PR. Thank you!

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
