### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/com/cloudbees/plugins/deployer/DeployNowComputer/sidepanel.jelly
+++ b/src/main/resources/com/cloudbees/plugins/deployer/DeployNowComputer/sidepanel.jelly
@@ -28,8 +28,8 @@
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back to List}" />
-      <l:task icon="images/24x24/search.png" href="${rootURL}/${it.url}" title="${%Status}" />
+      <l:task icon="icon-up icon-md" href=".." title="${%Back to List}" />
+      <l:task icon="icon-search icon-md" href="${rootURL}/${it.url}" title="${%Status}" />
       <t:actions />
     </l:tasks>
     <t:executors computers="${h.singletonList(it)}" />

--- a/src/main/resources/com/cloudbees/plugins/deployer/DeployNowProjectAction/configure.jelly
+++ b/src/main/resources/com/cloudbees/plugins/deployer/DeployNowProjectAction/configure.jelly
@@ -55,9 +55,8 @@
             <td class="setting-help">
               <a href="#" class="help-button"
                  helpURL="${rootURL}/plugin/deployer-framework/help-saveConfig.html">
-                <img src="${imagesURL}/16x16/help.png"
-                     alt="Help for feature: ${%Use this configuration as the default Deploy Now configuration for this project}"
-                     height="16" width="16"/>
+                <l:icon class="icon-help icon-sm"
+                     alt="Help for feature: ${%Use this configuration as the default Deploy Now configuration for this project}"/>
               </a>
             </td>
           </tr>
@@ -73,8 +72,7 @@
             <td class="setting-help">
               <a href="#" class="help-button"
                  helpURL="${rootURL}/plugin/deployer-framework/help-oneClickDeploy.html">
-                <img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${%Enable one-click deployment}"
-                     height="16" width="16"/>
+                <l:icon class="icon-help icon-sm" alt="Help for feature: ${%Enable one-click deployment}"/>
               </a>
             </td>
           </tr>

--- a/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/_deploy.jelly
+++ b/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/_deploy.jelly
@@ -34,7 +34,7 @@
      	</h1>
       <l:rightspace>
         <a href="deployText">
-          <img src="${imagesURL}/24x24/document.png" alt="" height="24" width="24" />${%View as plain text}
+          <l:icon class="icon-document icon-md" /> ${%View as plain text}
         </a>
       </l:rightspace>
       <j:set var="threshold" value="${h.getSystemProperty('hudson.consoleTailKB')?:'150'}" />

--- a/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/action.jelly
+++ b/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/action.jelly
@@ -28,7 +28,7 @@
     <l:task icon="${h.getIconFilePath(action)}" title="${action.displayName}"
             href="${h.getActionUrl(it.url,action)}">
       <j:if test="${action.hasOutput}">
-        <l:task icon="images/24x24/terminal.png"
+        <l:task icon="icon-terminal icon-md"
                 href="${h.getActionUrl(it.url,action)}/deploy" title="${%Output}"/>
       </j:if>
     </l:task>

--- a/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/configure.jelly
+++ b/src/main/resources/com/cloudbees/plugins/deployer/DeployNowRunAction/configure.jelly
@@ -46,9 +46,8 @@
             <td class="setting-help">
               <a href="#" class="help-button"
                  helpURL="${rootURL}/plugin/deployer-framework/help-saveConfig.html">
-                <img src="${imagesURL}/16x16/help.png"
-                     alt="Help for feature: ${%Use this configuration as the default Deploy Now configuration for this project}"
-                     height="16" width="16"/>
+                <l:icon class="icon-help icon-sm"
+                     alt="Help for feature: ${%Use this configuration as the default Deploy Now configuration for this project}"/>
               </a>
             </td>
           </tr>
@@ -64,8 +63,7 @@
             <td class="setting-help">
               <a href="#" class="help-button"
                  helpURL="${rootURL}/plugin/deployer-framework/help-oneClickDeploy.html">
-                <img src="${imagesURL}/16x16/help.png" alt="Help for feature: ${%Enable one-click deployment}"
-                     height="16" width="16"/>
+                <l:icon class="icon-help icon-sm" alt="Help for feature: ${%Enable one-click deployment}"/>
               </a>
             </td>
           </tr>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @batmat  
Thanks in advance!