### PR TITLE
Update parent pom to 4.46 and accompanying changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.33</version>
+    <version>4.46</version>
     <relativePath />
   </parent>
 
@@ -38,9 +38,6 @@
   <packaging>hpi</packaging>
 
   <name>Deployer Framework Plugin</name>
-  <description>
-    This plugin provides a framework for deploying applications.
-  </description>
   <url>https://github.com/jenkinsci/deployer-framework-plugin</url>
   <licenses>
     <license>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin provides a framework for deploying applications.
+</div>


### PR DESCRIPTION
`com.cloudbees.plugins.deployer.sources.StaticSelectionDeploySourceTest.doCheckFilePathWhenParamIsNotPathTraversalThenShouldOk` and `com.cloudbees.plugins.deployer.sources.WildcardPathDeploySourceTest.doCheckFilePatternWhenValueIsSymlinkThenReturnError` tests are flaky, parent pom 4.46 contain `jenkins-test-harness` with the fix.
