### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@ buildPlugin(configurations: [
     [platform: 'linux', jdk: '11'],
 
     // More recent with Guava & Guice bumps, only Linux
-    [ platform: "linux", jdk: "8", jenkins: '2.324', javaLevel: "8" ],
+    [ platform: "linux", jdk: "8", jenkins: '2.324' ],
 ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.